### PR TITLE
Fix in 'unsetopt nonomatch', it fails

### DIFF
--- a/autoload/gyazo.vim
+++ b/autoload/gyazo.vim
@@ -102,6 +102,10 @@ endfunction
 
 function! gyazo#post_from_current_window(...)
 	if executable("curl")
+		if s:invalid_zsh_option()
+			echoerr "Please add a setup 'setopt nonomatch' in .zshenv(not .zshrc)"
+			return ""
+		endif
 		let html = call("gyazo#make_html_from_current_window", [get(a:000, 1, {})])
 		let result = system(printf("curl -s -F file=@%s http://trickstar.herokuapp.com/api/gyazo/upload/?width=%d", html, 600))
 		let s:gyazo_last_post = result
@@ -109,6 +113,21 @@ function! gyazo#post_from_current_window(...)
 	else
 		return gyazo#post_from_image(call("gyazo#make_png_from_current_window", a:000))
 	endif
+endfunction
+
+
+function! s:invalid_zsh_option()
+	let is_zsh_active = exists("$SHELL") && (stridx($SHELL, "zsh") !=# -1)
+	return is_zsh_active && !s:is_zsh_option("nonomatch", "on")
+endfunction
+
+function! s:is_zsh_option(optname, expected_value)
+	" ex) set -o | grep nonomatch
+	"
+	" nonomatch             off
+	let option = system('set -o | grep ' . a:optname)
+	let matched = matchstr(option, printf('%s\s\+%s', a:optname, a:expected_value))
+	return !empty(matched)
 endfunction
 
 


### PR DESCRIPTION
.zshenvにて `setopt nonomatch` の設定がされていないと失敗するため、
以下の条件でチェックを行うようにしました。
- `$SHELL` が設定されている
- `$SHELL` に zsh という文字が含まれている
  - `/bin/zsh` や`/usr/bin/zsh` などパスが環境によって異なることを考慮
- `set -o` で取得した結果の `nonomatch` の値が `off` である

条件にすべて一致するとエラーメッセージを表示して処理を中断します。
